### PR TITLE
Updates for vlr

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,8 @@
-inherit_from: .rubocop_todo.yml
+# inherit_from: .rubocop_todo.yml
+
+plugins:
+  - rubocop-performance
+  - rubocop-rspec
 
 # The behavior of RuboCop can be controlled via the .rubocop.yml
 # configuration file. It makes it possible to enable/disable
@@ -12,9 +16,12 @@ inherit_from: .rubocop_todo.yml
 # See https://docs.rubocop.org/rubocop/configuration
 
 AllCops:
-  TargetRubyVersion: 2.7
-  NewCops: enable
+  TargetRubyVersion: 3.4
+  DisplayCopNames: true
+  DisabledByDefault: true
   Exclude:
+    - 'bin/*'
+    - 'coverage/*'
     - 'scratch.rb'
 
 Gemspec/RequireMFA:

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,13 @@
 
 source 'https://rubygems.org'
 
-gem 'rubocop', '~> 1.31', require: false
-gem 'rubocop-performance', '~> 1.15', require: false
-gem 'rubocop-rspec', '~> 2.12', require: false
+gem 'bundler', '>= 2.4'
+gem 'irb'
+gem 'rdoc'
+gem 'rspec', '~> 3.12'
+gem 'rubocop', '~> 1.78', require: false
+gem 'rubocop-performance', '~> 1.25', require: false
+gem 'rubocop-rspec', '~> 3.5', require: false
 
 gemspec
 

--- a/Rakefile
+++ b/Rakefile
@@ -8,8 +8,6 @@ RSpec::Core::RakeTask.new(:spec)
 begin
   require 'rubocop/rake_task'
   RuboCop::RakeTask.new(:rubocop) do |task|
-    task.requires << 'rubocop-rspec'
-    task.requires << 'rubocop-performance'
     task.fail_on_error = true
   end
 rescue LoadError

--- a/bin/console
+++ b/bin/console
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
-require 'pry'
 require 'omniauth-polaris'
 
-Pry.start
+require 'irb'
+IRB.start(__FILE__)

--- a/lib/omniauth/polaris/version.rb
+++ b/lib/omniauth/polaris/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module Polaris
-    VERSION = '1.1.1'
+    VERSION = '1.2.0'
   end
 end

--- a/omniauth-polaris.gemspec
+++ b/omniauth-polaris.gemspec
@@ -12,17 +12,13 @@ Gem::Specification.new do |gem|
   gem.summary = 'A Polaris API strategy for OmniAuth.'
   gem.homepage = 'https://github.com/boston-library/omniauth-polaris'
 
-  gem.required_ruby_version = '>= 2.6.10'
+  gem.required_ruby_version = '>= 3.4'
 
-  gem.add_dependency 'activesupport', '< 7'
-  gem.add_dependency 'http', '~> 5.1'
+  gem.add_dependency 'activesupport', '< 8'
+  gem.add_dependency 'http', '~> 5.2'
   gem.add_dependency 'omniauth', '~> 2.1.0'
 
-  gem.add_development_dependency 'awesome_print', '~> 1.9.2'
-  gem.add_development_dependency 'bundler', '>= 1.3.0'
-  gem.add_development_dependency 'libnotify', '~> 0.9.3'
-  gem.add_development_dependency 'pry', '~> 0.14'
-  gem.add_development_dependency 'rspec', '~> 3.12'
+  # gem.add_development_dependency 'libnotify', '~> 0.9.3'
 
   gem.files         = `git ls-files -z`.split("\x0")
   gem.executables   = gem.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/spec/omniauth/strategies/polaris_spec.rb
+++ b/spec/omniauth/strategies/polaris_spec.rb
@@ -25,7 +25,7 @@ describe 'OmniAuth::Strategies::Polaris' do
     before { post '/auth/polaris' }
 
     it 'is expected to display a form' do
-      expect(last_response.status).to be(200)
+      expect(last_response).to have_http_status(:ok)
       expect(last_response.body).to include('<form')
     end
 
@@ -56,7 +56,7 @@ describe 'OmniAuth::Strategies::Polaris' do
 
       it 'is expected to fail! with :missing_credentials' do
         post('/auth/polaris/callback', {})
-        expect(last_request.env['omniauth.error']).to be_a_kind_of(OmniAuth::Strategies::Polaris::MissingCredentialsError)
+        expect(last_request.env['omniauth.error']).to be_a(OmniAuth::Strategies::Polaris::MissingCredentialsError)
         expect(last_request.env['omniauth.error.type']).to be(:missing_credentials)
       end
 

--- a/spec/omniauth/strategies/polaris_spec.rb
+++ b/spec/omniauth/strategies/polaris_spec.rb
@@ -25,7 +25,7 @@ describe 'OmniAuth::Strategies::Polaris' do
     before { post '/auth/polaris' }
 
     it 'is expected to display a form' do
-      expect(last_response).to have_http_status(:ok)
+      expect(last_response.status).to be(200)
       expect(last_response.body).to include('<form')
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,8 +8,6 @@ ENV['RACK_ENV'] ||= 'test'
 require 'simplecov'
 SimpleCov.start
 
-require 'pry'
-require 'awesome_print'
 require 'rspec'
 require 'rack/test'
 require 'omniauth-polaris'


### PR DESCRIPTION
- Updated to use ruby >= 3.4

- Updated all dependencies

- Fixed `rubocop` issues

- Removed `pry` and `awesome_print`

- Fixed specs 